### PR TITLE
Improve tab accessibility with ARIA attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
     </section>
 
     <nav class="tabs" role="tablist" aria-label="AIニュース タブ">
-      <button class="tab active" data-target="business" role="tab" aria-selected="true">ビジネス</button>
-      <button class="tab" data-target="tools" role="tab" aria-selected="false">ツール</button>
-      <button class="tab" data-target="company" role="tab" aria-selected="false">企業動向</button>
-      <button class="tab" data-target="sns" role="tab" aria-selected="false">SNSまとめ</button>
+      <button id="tab-business" class="tab active" data-target="business" role="tab" aria-selected="true" aria-controls="business" tabindex="0">ビジネス</button>
+      <button id="tab-tools" class="tab" data-target="tools" role="tab" aria-selected="false" aria-controls="tools" tabindex="-1">ツール</button>
+      <button id="tab-company" class="tab" data-target="company" role="tab" aria-selected="false" aria-controls="company" tabindex="-1">企業動向</button>
+      <button id="tab-sns" class="tab" data-target="sns" role="tab" aria-selected="false" aria-controls="sns" tabindex="-1">SNSまとめ</button>
     </nav>
 
     <noscript>
@@ -39,7 +39,7 @@
     </noscript>
 
     <!-- Business -->
-    <div id="business" class="tab-content" role="tabpanel">
+    <div id="business" class="tab-content" role="tabpanel" aria-hidden="false">
       <div class="card-list">
         <article class="card">
           <span class="category">買収</span><span class="stars">★★★☆☆</span>
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Tools -->
-    <div id="tools" class="tab-content" role="tabpanel" hidden>
+    <div id="tools" class="tab-content" role="tabpanel" hidden aria-hidden="true">
       <div class="card-list">
         <article class="card">
           <span class="category">障害対応</span><span class="stars">★★★☆☆</span>
@@ -75,7 +75,7 @@
     </div>
 
     <!-- Company -->
-    <div id="company" class="tab-content" role="tabpanel" hidden>
+    <div id="company" class="tab-content" role="tabpanel" hidden aria-hidden="true">
       <div class="card-list">
         <article class="card">
           <span class="category">規制/供給網</span><span class="stars">★★★☆☆</span>
@@ -93,7 +93,7 @@
     </div>
 
     <!-- SNS (AI-related posts with working links only) -->
-    <div id="sns" class="tab-content" role="tabpanel" hidden>
+    <div id="sns" class="tab-content" role="tabpanel" hidden aria-hidden="true">
       <p class="sns-note">※ AIモデル/プロダクト/企業動向に直接関係する投稿のみ掲載。全件URL付き。</p>
       <div class="card-list">
         <article class="card">
@@ -166,12 +166,30 @@
 // Tab switching
 document.querySelectorAll('.tab').forEach(btn => {
   btn.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.tab-content').forEach(c => c.hidden = true);
+    const tabs = document.querySelectorAll('.tab');
+    const panels = document.querySelectorAll('.tab-content');
+
+    tabs.forEach(t => {
+      t.classList.remove('active');
+      t.setAttribute('aria-selected', 'false');
+      t.setAttribute('tabindex', '-1');
+    });
+
+    panels.forEach(p => {
+      p.hidden = true;
+      p.setAttribute('aria-hidden', 'true');
+    });
+
     btn.classList.add('active');
-    const id = btn.getAttribute('data-target');
+    btn.setAttribute('aria-selected', 'true');
+    btn.setAttribute('tabindex', '0');
+
+    const id = btn.getAttribute('aria-controls');
     const panel = document.getElementById(id);
-    if (panel) panel.hidden = false;
+    if (panel) {
+      panel.hidden = false;
+      panel.setAttribute('aria-hidden', 'false');
+    }
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- Link tab buttons to their panels using ids and `aria-controls`
- Toggle `aria-selected`, `tabindex`, and `aria-hidden` attributes during tab switches for accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976ce34a348328911f802196be6bfa