### PR TITLE
Fetch feeds with requests and log failures

### DIFF
--- a/scripts/build_news.py
+++ b/scripts/build_news.py
@@ -56,7 +56,12 @@ def head_ok(url: str) -> bool:
 
 def fetch_feed(url: str):
     log('feed:', url)
-    d = feedparser.parse(url)
+    try:
+        r = requests.get(url, headers=UA, timeout=GET_TIMEOUT)
+        d = feedparser.parse(r.content)
+    except Exception as ex:
+        log('feed err', url, ex)
+        return []
     items = []
     for e in d.entries[:MAX_FEED_ITEMS]:
         title = e.get('title', '').strip()


### PR DESCRIPTION
## Summary
- Fetch RSS feeds via requests and parse response content with feedparser
- Log failures when fetching feeds and return empty list

## Testing
- `pytest`
- `python -m py_compile scripts/build_news.py`


------
https://chatgpt.com/codex/tasks/task_e_6899625e17ac83289b907f40ff18d66e