### PR TITLE
Skip URL verification when in fast mode

### DIFF
--- a/scripts/build_news.py
+++ b/scripts/build_news.py
@@ -256,7 +256,10 @@ def main():
         if any(very_similar(it['title'], p['title']) for p in pruned): continue
         pruned.append(it)
 
-    verified = [it for it in pruned if head_ok(it['url'])]
+    if FAST:
+        verified = pruned
+    else:
+        verified = [it for it in pruned if head_ok(it['url'])]
 
     cutoff = datetime.now(JST) - timedelta(hours=24)
     recent = []


### PR DESCRIPTION
## Summary
- Skip head_ok() checks and use pruned list directly when FAST_MODE is enabled

## Testing
- `python -m py_compile scripts/build_news.py`


------
https://chatgpt.com/codex/tasks/task_e_6899626236488328a8302b0f1dd707ad